### PR TITLE
Docs: add notes from the mentoring session 23/04/2025

### DIFF
--- a/notes/2025.04_23_HashMaps_HashSets.md
+++ b/notes/2025.04_23_HashMaps_HashSets.md
@@ -29,3 +29,7 @@
     . add pylint
     . add github actions step with pylint
 
+General notes:
+    . Don't need that many comments, makes it harder to read the code
+    . Improve branch names and merge them to main, why are they merging between themselves? 
+    . Implementation and corresponding test can (and should) be in the same PR. Maybe different commits

--- a/notes/2025.04_23_HashMaps_HashSets.md
+++ b/notes/2025.04_23_HashMaps_HashSets.md
@@ -1,0 +1,31 @@
+1. Revisão do Exrecício WordSearch Cobra:
+    . Demasiados comentários ao longo do código - eliminar;
+    . Não é errado, mas não é boa prática construir funções dentro de funções - pôr a função 'search' para fora da função 'exist'.
+
+2. Em termos da atividade no GitHub:
+    . Melhorar a criação das branches. Devemos sempre criar uma branch a partir de main, por tanto, as próximas branches é fazer pull requests a comparar com main - importante: ter main cmo default!
+    . Apagar o first branch - sempre que se faz merge, apaga-se o branch.
+
+3. No seguimento do exercício da WordSearch, fazer este exercício:
+    . Given a rod of length n inches and an array price[]. price[i] denotes the value of a piece of length i. The task is to determine the maximum value obtainable by cutting up the rod and selling the pieces.
+    Input: price[] =  [1, 5, 8, 9, 10, 17, 17, 20]
+    Output: 22
+    Explanation:  The maximum obtainable value is 22 by cutting in two pieces of lengths 2 and 6, i.e., 5 + 17 = 22.
+    Input : price[] =  [3, 5, 8, 9, 10, 17, 17, 20]
+    Output : 24
+    Explanation : The maximum obtainable value is 24 by cutting the rodinto 8 pieces of length 1, i.e, 8price[1]= 83 = 24.
+
+4. Pesquisar:
+    . What are hash maps (dicts in python);
+    . What are hash sets.
+
+5. Com base nos conceitos anteriores:
+    . Input baralho: ["2", "3", "4", "5", "6", "7"]
+    . Cartas na gaveta: "6","7", "3","4", "4", "4", "4","5","5","3", "4", "7", "4","6", "6", "2","3","3","5", "4", "4","2","7","7"
+    . Solution: 2
+
+6. For CI:
+    . add github actions with the pytest
+    . add pylint
+    . add github actions step with pylint
+


### PR DESCRIPTION
Added new file 2025_04_23_HashMaps with notes from the mentoring session held on 23/04/2025.

**Notes:**
1. Review of the WordSearch Cobra exercise (good code practices);
2. Improvements to the process of creating and managing branches on GitHub;
3. New exercise proposed: classic Rod Cutting Problem.

**Study topics:** 
1. Hash Maps and Hash Sets;
2. Practical exercise related to playing cards;
3. Introduction of good practices for continuous integration (CI) with GitHub Actions, Pytest and Pylint.

**General notes** reinforced the importance of:
1. Reducing excessive comments in the code;
2. Improving branch names and their integration flow;
3. Grouping implementation and tests in the same Pull Request, separating them by commits when necessary.