### PR TITLE
docs: add session notes 2025.05.13

### DIFF
--- a/notes/2025.05.13_GitHubReview.md
+++ b/notes/2025.05.13_GitHubReview.md
@@ -1,0 +1,25 @@
+1. Revisão de conceitos de GitHub:
+
+. Após criar um Pull Request (PR), pode haver conflitos entre o meu branch e o main. Esses conflitos surgem quando o código em main foi alterado depois de ter criado o meu branch. Existem duas formas principais de resolver estes conflitos via terminal:
+
+    - Método 1: Reset + Rebase + Cherry-pick:
+a. Fazer reset ao branch atual para remover os commits temporariamente, com git reset --hard HEAD~n, em que:
+    n corresponde ao número de commits que quero remover (contar desde o mais recente até ao primeiro commit que é para preservar) - isto "apaga" os commits locais, mas não os elimina completamente — eles ainda podem ser reaplicados com o cherry-pick;
+b. Atualizar o branch a partir do main com rebase, com git rebase origin/main, em que:
+    traz as últimas alterações de main para o meu branch
+c. Reaplicar os commits antigos individualmente, com git cherry-pick <hash_do_commit>, em que:
+    é necessário usar o git log --oneline (antes do reset) para copiar os hashes dos commits importantes que é necessário reaplicar  
+d. Fazer push forçado para atualizar o PR, com git push -f
+
+    - Método 2: Pull + Merge + Push:
+a. Voltar para o branch e fazer merge da main, com git checkout nome-do-teu-branch e git merge main
+b. Se houver conflitos, o Git vai avisar. Resolver os conflitos manualmente, guardar os ficheiros e depois, com git add . e git commit
+c. Fazer push para atualizar o PR, com git push origin nome-do-branch
+
+ATENÇÃO: para ambos os métodos é sempre necessário começar com git checkout main e git pull origin main, para atualizar a main localmente!
+
+2. Rever o workflow de gitHubActions, já que  exit-0 não é o comando correto --> ignora na mesma aos erros
+
+3. Modificar exercício Binário --- não somar strings, trabalhar com numérico
+
+4. O que são listas ligadas??? Pesquisar 'linked lists'.


### PR DESCRIPTION
This PR adds a new notes file containing the following content:

. **GitHub Concepts Review:**
1. Explanation of potential conflicts when creating a PR after changes have been made to main;
2. Two main methods for resolving conflicts:
     a. Method 1: reset + rebase + cherry-pick;
     b. Method 2: pull + merge + push;
3. Important reminder to always start by updating the local main with git checkout main and git pull origin main.

. **GitHub Actions Workflow Review:**
Need to review the usage of exit 0, since it may silently ignore errors instead of handling them properly.

. **Binary Exercise Update:**
Note to avoid summing string values; numeric operations should be used instead.

. **Further Study:**
Reminder to research the concept of linked lists.