### PR TITLE
feat/shapes polymorphism

### DIFF
--- a/exercises/shapesPolymorphismExercise/shapes.java
+++ b/exercises/shapesPolymorphismExercise/shapes.java
@@ -37,3 +37,23 @@ class Square extends Shape {
         return 4 * side;
     }
 }
+
+class Circle extends Shape {
+    double radius;
+
+    Circle(double radius) {
+        this.radius = radius;
+    }
+
+    double getArea() {
+        return Math.PI * radius * radius;
+    }
+
+    double getPerimeter() {
+        return 2 * Math.PI * radius; 
+    }
+
+    double getRadius() {
+        return radius;
+    }
+}

--- a/exercises/shapesPolymorphismExercise/shapes.java
+++ b/exercises/shapesPolymorphismExercise/shapes.java
@@ -21,3 +21,19 @@ class Triangle extends Shape {
         return sideA + sideB + sideC;
     }
 }
+
+class Square extends Shape {
+    double side;
+
+    Square(double side) {
+        this.side = side;
+    }
+
+    double getArea() {
+        return side * side;
+    }
+
+    double getPerimeter() {
+        return 4 * side;
+    }
+}

--- a/exercises/shapesPolymorphismExercise/shapes.java
+++ b/exercises/shapesPolymorphismExercise/shapes.java
@@ -1,0 +1,4 @@
+abstract class Shape {
+    abstract double getArea();
+    abstract double getPerimeter();
+}

--- a/exercises/shapesPolymorphismExercise/shapes.java
+++ b/exercises/shapesPolymorphismExercise/shapes.java
@@ -57,3 +57,25 @@ class Circle extends Shape {
         return radius;
     }
 }
+
+public class Main {
+    public static void main(String[] args) {
+        Shape[] shapes = {
+            new Triangle(3, 4, 5, 2),
+            new Square(4),
+            new Circle(3)
+        };
+
+        for (Shape shape: shapes) {
+            System.out.println("Área: " + shape.getArea());
+            System.out.println("Perímetro: " + shape.getPerimeter());
+
+            if (shape instanceof Circle) {
+                Circle c = (Circle) shape;
+                System.out.println("Raio: " + c.getRadius());
+            }
+
+            System.out.println("-----------")
+        }
+    }
+}

--- a/exercises/shapesPolymorphismExercise/shapes.java
+++ b/exercises/shapesPolymorphismExercise/shapes.java
@@ -2,3 +2,22 @@ abstract class Shape {
     abstract double getArea();
     abstract double getPerimeter();
 }
+
+class Triangle extends Shape {
+    double sideA, sideB, sideC, height;
+
+    Triangle(double a, double b, double c, double h) {
+        this.sideA = a;
+        this.sideB = b;
+        this.sideC = c;
+        this.height = h;
+    }
+
+    double getArea() {
+        return (sideA * height) / 2;
+    }
+
+    double getPerimeter() {
+        return sideA + sideB + sideC;
+    }
+}

--- a/exercises/shapesPolymorphismExercise/shapes.js
+++ b/exercises/shapesPolymorphismExercise/shapes.js
@@ -1,0 +1,83 @@
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var shape = /** @class */ (function () {
+    function shape() {
+    }
+    return shape;
+}());
+var triangle = /** @class */ (function (_super) {
+    __extends(triangle, _super);
+    function triangle(a, b, c, height) {
+        var _this = _super.call(this) || this;
+        _this.side_A = a;
+        _this.side_B = b;
+        _this.side_C = c;
+        _this.height = height;
+        return _this;
+    }
+    triangle.prototype.get_area = function () {
+        return (this.side_A * this.height) / 2;
+    };
+    triangle.prototype.get_perimeter = function () {
+        return (this.side_A + this.side_B + this.side_C);
+    };
+    return triangle;
+}(shape));
+var square = /** @class */ (function (_super) {
+    __extends(square, _super);
+    function square(side) {
+        var _this = _super.call(this) || this;
+        _this.side = side;
+        return _this;
+    }
+    square.prototype.get_area = function () {
+        return this.side * this.side;
+    };
+    square.prototype.get_perimeter = function () {
+        return this.side * 4;
+    };
+    return square;
+}(shape));
+var circle = /** @class */ (function (_super) {
+    __extends(circle, _super);
+    function circle(radius) {
+        var _this = _super.call(this) || this;
+        _this.radius = radius;
+        return _this;
+    }
+    circle.prototype.get_area = function () {
+        return Math.PI * this.radius * this.radius;
+    };
+    circle.prototype.get_perimeter = function () {
+        return 2 * Math.PI * this.radius;
+    };
+    circle.prototype.get_radius = function () {
+        return this.radius;
+    };
+    return circle;
+}(shape));
+var tri = new triangle(2, 4, 5, 2);
+var sqr = new square(4);
+var crc = new circle(3);
+var shapes = [tri, sqr, crc];
+for (var _i = 0, shapes_1 = shapes; _i < shapes_1.length; _i++) {
+    var _shape = shapes_1[_i];
+    console.log("Area:", _shape.get_area());
+    console.log("Perimeter:", _shape.get_perimeter());
+    if (_shape instanceof circle) {
+        console.log("Raio:", _shape.get_radius());
+    }
+}

--- a/exercises/shapesPolymorphismExercise/shapes.ts
+++ b/exercises/shapesPolymorphismExercise/shapes.ts
@@ -1,9 +1,9 @@
-abstract class shape {
+abstract class my_shape {
     abstract get_area(): number;
     abstract get_perimeter(): number;
 }
 
-class triangle extends shape {
+class my_triangle extends my_shape {
     side_A: number;
     side_B: number;
     side_C: number;
@@ -26,7 +26,7 @@ class triangle extends shape {
     }
 }
 
-class square extends shape {
+class my_square extends my_shape {
     side: number;
 
     constructor(side: number) {
@@ -43,7 +43,7 @@ class square extends shape {
     }
 }
 
-class circle extends shape {
+class my_circle extends my_shape {
     radius: number;
 
     constructor(radius: number) {
@@ -64,13 +64,13 @@ class circle extends shape {
     }
 }
 
-const tri = new triangle(2, 4, 5, 2);
-const sqr = new square(4);
-const crc = new circle(3);
+const triangle_ = new my_triangle(2, 4, 5, 2);
+const square_ = new my_square(4);
+const circle_ = new my_circle(3);
 
-const shapes: shape[] = [tri, sqr, crc];
+const shapes_: my_shape[] = [tri, sqr, crc];
 
-for (const _shape of shapes) {
+for (const _shape of shapes_) {
     console.log("Area:", _shape.get_area());
     console.log("Perimeter:", _shape.get_perimeter());
 

--- a/exercises/shapesPolymorphismExercise/shapes.ts
+++ b/exercises/shapesPolymorphismExercise/shapes.ts
@@ -68,13 +68,13 @@ const triangle_ = new my_triangle(2, 4, 5, 2);
 const square_ = new my_square(4);
 const circle_ = new my_circle(3);
 
-const shapes_: my_shape[] = [tri, sqr, crc];
+const shapes_: my_shape[] = [triangle_, square_, circle_];
 
 for (const _shape of shapes_) {
     console.log("Area:", _shape.get_area());
     console.log("Perimeter:", _shape.get_perimeter());
 
-    if (_shape instanceof circle) {
+    if (_shape instanceof my_circle) {
         console.log("Raio:", _shape.get_radius());
     }
 }

--- a/exercises/shapesPolymorphismExercise/shapes.ts
+++ b/exercises/shapesPolymorphismExercise/shapes.ts
@@ -2,3 +2,26 @@ abstract class shape {
     abstract get_area(): number;
     abstract get_perimeter(): number;
 }
+
+class triangle extends shape {
+    side_A: number;
+    side_B: number;
+    side_C: number;
+    height: number;
+
+    constructor(a: number, b: number, c: number, height: number) {
+        super();
+        this.side_A = a;
+        this.side_B = b;
+        this.side_C = c;
+        this.height = height
+    }
+
+    get_area(): number {
+        return (this.side_A * this.height) / 2;
+    }
+
+    get_perimeter(): number {
+        return (this.side_A + this.side_B + this.side_C);
+    }
+}

--- a/exercises/shapesPolymorphismExercise/shapes.ts
+++ b/exercises/shapesPolymorphismExercise/shapes.ts
@@ -63,3 +63,18 @@ class circle extends shape {
         return this.radius;
     }
 }
+
+const tri = new triangle(2, 4, 5, 2);
+const sqr = new square(4);
+const crc = new circle(3);
+
+const shapes: shape[] = [tri, sqr, crc];
+
+for (const _shape of shapes) {
+    console.log("Area:", _shape.get_area());
+    console.log("Perimeter:", _shape.get_perimeter());
+
+    if (_shape instanceof circle) {
+        console.log("Raio:", _shape.get_radius());
+    }
+}

--- a/exercises/shapesPolymorphismExercise/shapes.ts
+++ b/exercises/shapesPolymorphismExercise/shapes.ts
@@ -1,0 +1,4 @@
+abstract class shape {
+    abstract get_area(): number;
+    abstract get_perimeter(): number;
+}

--- a/exercises/shapesPolymorphismExercise/shapes.ts
+++ b/exercises/shapesPolymorphismExercise/shapes.ts
@@ -42,3 +42,24 @@ class square extends shape {
         return this.side * 4;
     }
 }
+
+class circle extends shape {
+    radius: number;
+
+    constructor(radius: number) {
+        super();
+        this.radius = radius;
+    }
+
+    get_area(): number {
+        return Math.PI * this.radius * this.radius;
+    }
+
+    get_perimeter(): number {
+        return 2 * Math.PI * this.radius;
+    }
+
+    get_radius(): number {
+        return this.radius;
+    }
+}

--- a/exercises/shapesPolymorphismExercise/shapes.ts
+++ b/exercises/shapesPolymorphismExercise/shapes.ts
@@ -25,3 +25,20 @@ class triangle extends shape {
         return (this.side_A + this.side_B + this.side_C);
     }
 }
+
+class square extends shape {
+    side: number;
+
+    constructor(side: number) {
+        super();
+        this.side = side;
+    }
+
+    get_area(): number {
+        return this.side * this.side;
+    }
+
+    get_perimeter(): number {
+        return this.side * 4;
+    }
+}


### PR DESCRIPTION
This pull request introduces an example of polymorphism in both Java and TypeScript.
The goal is to demonstrate how polymorphism works through a common `Shape` abstraction, implemented in two popular languages. 

1. **TypeScript Implementation**:
   a. Abstract class: 'Shape';
   b. Subclasses: 'Triangle', 'Square', 'Circle';
   c. Each shape class implements: 'getArea(): number', 'getPerimeter(): number', and 'Circle' has a specific method: 'getRadius(): number'.

2. **Java Implementation**:
   a. Abstract class: 'Shape';
   b. Subclasses: 'Triangle', 'Square', 'Circle';
   c. Each subclass implements its own versions of: 'getArea()', 'getPerimeter()', and 'Circle' also includes a specific method: 'getRadius()';
   d. A 'Main' class runs examples with all shapes and prints the results to the console.