### PR TITLE
ci: update .gitignore file so all .iml files cannot be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/__pycache__/
 *.pyc
 *.idea
+*.iml


### PR DESCRIPTION
This PR consists of an update to the '.gitignore' file so that all files with an .iml extension are not comitted.